### PR TITLE
refactor:좋아요 정렬 수정 및 post 일부 수정

### DIFF
--- a/newspeed/src/main/java/com/example/newspeed/post/controller/PostController.java
+++ b/newspeed/src/main/java/com/example/newspeed/post/controller/PostController.java
@@ -52,10 +52,9 @@ public class PostController {
     //좋아요 수 기준
     @GetMapping("/sort/likes")
     public ResponseEntity<Page<Post>> findPostsByLikes(@RequestParam(defaultValue = "0") int page,
-                                                      @RequestParam(defaultValue = "10") int size,
-                                                      @PathVariable("postId") Long postId) {
+                                                      @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("modifiedAt").descending());
-        Page<Post> posts = postService.findAllPostsByLikes(pageable, postId);
+        Page<Post> posts = postService.findAllPostsByLikes(pageable);
         return ResponseEntity.ok(posts);
     }
 

--- a/newspeed/src/main/java/com/example/newspeed/post/repository/PostRepository.java
+++ b/newspeed/src/main/java/com/example/newspeed/post/repository/PostRepository.java
@@ -26,13 +26,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByUpdatedAtBetweenOrderByUpdatedAt(Pageable pageable, LocalDateTime startDate, LocalDateTime endDate);
     //좋아요 기준 게시물 조회
     @Query("""
-    SELECT p, COUNT(l) as likeCount
+    SELECT p
     FROM Post p
     LEFT JOIN Like l ON p.postId = l.post.postId
     GROUP BY p.postId
-    ORDER BY likeCount DESC, p.updatedAt DESC
+    ORDER BY COUNT(l) DESC, p.updatedAt DESC
     """)
-    Page<Post> findAllByLikeCount(Pageable pageable, Long postId);
+    Page<Post> findAllByLikeCount(Pageable pageable);
     // 유저 ID로 모든 게시물을 조회하는 메소드
     List<Post> findByUserId(Long userId);
 }

--- a/newspeed/src/main/java/com/example/newspeed/post/service/PostService.java
+++ b/newspeed/src/main/java/com/example/newspeed/post/service/PostService.java
@@ -35,8 +35,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Post> findAllPostsByLikes(Pageable pageable, Long postId) {
-        return postRepository.findAllByLikeCount(pageable, postId);
+    public Page<Post> findAllPostsByLikes(Pageable pageable) {
+        return postRepository.findAllByLikeCount(pageable);
     }
 
     public PostResponse findPostById(Long postId) {

--- a/newspeed/src/main/resources/application.properties
+++ b/newspeed/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=newspeed
 
 spring.datasource.url=jdbc:mysql://localhost:3306/newspeed
 spring.datasource.username=root
-spring.datasource.password=spar7097
+spring.datasource.password=85947ads
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
이전 코드는 PostController의 좋아요 정렬 엔드포인트에서 @PathVariable("postId")LOng postId를 받고 있었음
-> 좋아요 정렬 기능은 특정 게시글의 Id가 아니라, 전체 게시글의 좋아요 집계의 결과를 기준으로 정렬한다고 생각했습니다.
-> 이와 더불어 Repository와 Service에 불필요한 postId를 받고록 되어있는 파라미터 수정하였습니다.

1. PostRepository
2. PostService
3. PostContoroller

꼭 수정해야하는 이유에 대해 왜 그런지에 대해 다시 생각을 하고, 피드백을 요청합니다.
-  앞서 말했듯이 좋아요 정렬은 모든 게시글에 대한 좋아요 집계 결과로 정렬하는 기능이므로, 특정 게시글 id를 받을 피룡가 없다고 생각했으며, 이를 개선한다면 api인터페이스가 더욱 명확해져 가독성이 좋아지며 이에따라 코드가 간결해지고, 추후 수정이나 확장이 필요할 때 혼란을 줄일 수 있습니다. 이에 따른 쿼리도 수정했습니다.