### PR TITLE
Feat/friendship

### DIFF
--- a/newspeed/src/main/java/com/example/newspeed/friend/entity/Friend.java
+++ b/newspeed/src/main/java/com/example/newspeed/friend/entity/Friend.java
@@ -26,7 +26,6 @@ public class Friend extends BaseEntity {
     @JoinColumn(name = "receiver_id", nullable = false)
     private User receiver;
 
-    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private FriendStatus status = FriendStatus.PENDING;
@@ -35,5 +34,9 @@ public class Friend extends BaseEntity {
         this.requester = requester;
         this.receiver = receiver;
         this.status = status;
+    }
+
+    public void accept() {
+        this.status = FriendStatus.ACCEPTED;
     }
 }

--- a/newspeed/src/main/java/com/example/newspeed/friend/service/FriendService.java
+++ b/newspeed/src/main/java/com/example/newspeed/friend/service/FriendService.java
@@ -39,16 +39,12 @@ public class FriendService {
     public FriendResponseDto acceptFriendRequest(Long requesterId) {
         Friend friend = friendRepository.findById(requesterId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 친구 요청입니다"));
-        friend.setStatus(FriendStatus.ACCEPTED);
+        friend.accept();
         Friend savedFriend = friendRepository.save(friend);
         return FriendResponseDto.toDto(savedFriend);
     }
 
     public void removeFriend(Long requesterId, Long receiverId) {
-        userRepository.findById(requesterId)
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자 아이디입니다"));
-        userRepository.findById(receiverId)
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자 아이디입니다"));
         Friend friend = friendRepository.findByRequesterIdAndReceiverId(requesterId, receiverId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 친구 관계입니다"));
         friendRepository.delete(friend);


### PR DESCRIPTION
친구 삭제 부분에서 친구 데이터 조회 쿼리가 친구 유효성 검사에 적합하다고 생각했습니다
작성자 데이터 존재하는지 판단하는 쿼리는 불필요하다고 판단해 제거했습니다
setter가 불분명한 목적으로 사용되는 것을 막고자 accept() 의 친구 요청 메서드 생성했습니다