### PR TITLE
fix:jpa조건 때문에 에러 발생. 메서드 이름에서 조건 부분을 제거하고, 정렬만을 나타내도록 이름을 변경

### DIFF
--- a/newspeed/src/main/java/com/example/newspeed/comment/controller/CommentController.java
+++ b/newspeed/src/main/java/com/example/newspeed/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.example.newspeed.comment.dto.request.CommentUpdateRequestDto;
 import com.example.newspeed.comment.dto.response.CommentResponseDto;
 import com.example.newspeed.comment.service.CommentService;
 import com.example.newspeed.common.jwt.JwtUtil;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +23,7 @@ public class CommentController {
     public ResponseEntity<CommentResponseDto> save(
             @RequestHeader("Authorization") String token,
             @PathVariable Long postId,
-            @RequestBody CommentSaveRequestDto dto
+            @RequestBody @Valid CommentSaveRequestDto dto
             ){
         Long userId=jwtUtil.getUserIdFromJwtToken(token);
         return ResponseEntity.ok(commentService.save(userId, postId, dto));

--- a/newspeed/src/main/java/com/example/newspeed/common/jwt/JwtUtil.java
+++ b/newspeed/src/main/java/com/example/newspeed/common/jwt/JwtUtil.java
@@ -26,9 +26,10 @@ public class JwtUtil {
 //                .signWith(SignatureAlgorithm.HS512, jwtSecret)
 //                .compact();
 //    }
-    public String generateJwtToken(String email) {
+    public String generateJwtToken(String email,Long userId) {
         return Jwts.builder()
                 .setSubject(email)
+                .claim("userId", userId.toString())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationMs))
                 .signWith(Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)

--- a/newspeed/src/main/java/com/example/newspeed/post/repository/PostRepository.java
+++ b/newspeed/src/main/java/com/example/newspeed/post/repository/PostRepository.java
@@ -25,14 +25,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     //수정일 기준 시작일과 종료일로 게시물 조회
     Page<Post> findAllByUpdatedAtBetweenOrderByUpdatedAt(Pageable pageable, LocalDateTime startDate, LocalDateTime endDate);
     //좋아요 기준 게시물 조회
-    @Query("""
-    SELECT p
-    FROM Post p
-    LEFT JOIN Like l ON p.postId = l.post.postId
-    GROUP BY p.postId
-    ORDER BY COUNT(l) DESC, p.updatedAt DESC
-    """)
-    Page<Post> findAllByLikeCount(Pageable pageable);
+    Page<Post> findAllByOrderByLikeCountDescUpdatedAtDesc(Pageable pageable);
     // 유저 ID로 모든 게시물을 조회하는 메소드
     List<Post> findByUserId(Long userId);
 }

--- a/newspeed/src/main/java/com/example/newspeed/post/service/PostService.java
+++ b/newspeed/src/main/java/com/example/newspeed/post/service/PostService.java
@@ -44,8 +44,9 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public Page<Post> findAllPostsByLikes(Pageable pageable) {
-        return postRepository.findAllByLikeCount(pageable);
+        return postRepository.findAllByOrderByLikeCountDescUpdatedAtDesc(pageable);
     }
+
 
     public PostResponse findPostById(Long postId) {
         Post post = postRepository.findById(postId)

--- a/newspeed/src/main/java/com/example/newspeed/user/controller/AuthController.java
+++ b/newspeed/src/main/java/com/example/newspeed/user/controller/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<JwtResponse> login(@RequestBody UserLoginRequestDto dto) {
         User user = authService.login(dto);
-        String token = jwtUtil.generateJwtToken(user.getEmail());
+        String token = jwtUtil.generateJwtToken(user.getEmail(), user.getId());
         JwtResponse jwtResponse = new JwtResponse(token, user.getId(), user.getEmail());
         return ResponseEntity.ok(jwtResponse);
     }


### PR DESCRIPTION
- Spring Data JPA는 "findAllByLikeCount"라는 부분을 조건(예: likeCount = ? 또는 likeCount > ? 등)으로 인식하기때문에,
 최소한 하나의 인자가 필요하다고 판단합니다. 그리고 저희는 단순히 정렬만 원하므로 조건은 필요하지 않습니다.
따라서, 해결 방법은 메서드 이름에서 조건 부분을 제거하고, 정렬만을 나타내도록 이름을 변경하는 것입니다.